### PR TITLE
allow `hiMom` to accept `motherName` argument (optional)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-export function hiMom(): string;
+export function hiMom(motherName?: string): string;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-export function hiMom() {
-  return "Hi, mom!";
+export function hiMom(motherName = 'mom') {
+  return `Hi, ${motherName}!`;
 }

--- a/index.test.js
+++ b/index.test.js
@@ -7,3 +7,7 @@ test("should say hi to mom", () => {
 test("should not say hi to dad", () => {
   expect(hiMom()).not.toBe("Hi, dad!");
 });
+
+test("should say hi to Mother when requested", () => {
+  expect(hiMom('Mother')).toBe("Hi, Mother!");
+});


### PR DESCRIPTION
Not everyone refers to their mother as "mom". Some use the term "mum" or "ma", or for the more estranged among us, "Linda".

This PR should hopefully rectify this oversight, while retaining the blazing fast nature of the project overall.