### PR TITLE
Fix nonsense Korean language

### DIFF
--- a/languages/index.js
+++ b/languages/index.js
@@ -23,7 +23,7 @@ export default {
   id: "Hai, {{ibu}}!",
   it: "Ciao {{mamma}}!",
   ja: "こんにちは、{{ママ}}!",
-  ko: "안녕하세요, {{마모}}!",
+  ko: "안녕, {{엄마}}!",
   kaa: "Sálem, {{anajan}}!",
   lt: "Labas, {{mama}}!",
   ms: "Hai, {{bapa}}!",


### PR DESCRIPTION
- 안녕 is more often considered as an equivalent of "hi", whereas 안녕하세요 is normally considered as like "hello".
- 엄마 is the correct translation of "mom". 마모 makes no sense in this context.